### PR TITLE
Fix nav links blocked by overlay

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8,6 +8,7 @@ body {
     position: absolute;
     top: 10px;
     right: 20px;
+    z-index: 1000;
 }
 .top-nav a {
     margin-left: 15px;


### PR DESCRIPTION
## Summary
- ensure navigation links sit on top of hero overlay by adding a `z-index`

## Testing
- `npm test` *(fails: no test specified)*