### PR TITLE
Fix Juncheng InfoTech logo clipping

### DIFF
--- a/images/logo.svg
+++ b/images/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="420" height="100" viewBox="0 0 210 50">
+<svg xmlns="http://www.w3.org/2000/svg" width="520" height="100" viewBox="0 0 260 50">
   <defs>
     <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#00ffff"/>


### PR DESCRIPTION
## Summary
- expand logo SVG viewBox to keep full text visible

## Testing
- `npm test` *(fails: Error: no test specified)*